### PR TITLE
Move crossplane-dapr workflow to repo-level workflows

### DIFF
--- a/.github/workflows/crossplane-dapr.yml
+++ b/.github/workflows/crossplane-dapr.yml
@@ -3,15 +3,20 @@ name: crossplane-dapr-ci
 on:
   push:
     paths:
-      - '**'
+      - 'crossplane-dapr/**'
+      - '.github/workflows/crossplane-dapr.yml'
   pull_request:
     paths:
-      - '**'
+      - 'crossplane-dapr/**'
+      - '.github/workflows/crossplane-dapr.yml'
   workflow_dispatch:
 
 jobs:
   shift-left:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crossplane-dapr
 
     steps:
       - name: Checkout
@@ -56,6 +61,9 @@ jobs:
   e2e-smoke:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crossplane-dapr
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for the Crossplane Dapr integration. The main changes are to scope the workflow triggers and job execution to the appropriate subdirectory, and to move the workflow file to a more standard location.

Workflow configuration improvements:

* Updated the workflow triggers so that the workflow only runs when changes are made to files under `crossplane-dapr/**` or to the workflow file itself, instead of any file in the repository.
* Added `working-directory: crossplane-dapr` defaults for all jobs to ensure commands run in the correct subdirectory. [[1]](diffhunk://#diff-c404cbc5e55acef134916091ee4b3682a866a52e67096083a729a3bdafcb24e2L6-R19) [[2]](diffhunk://#diff-c404cbc5e55acef134916091ee4b3682a866a52e67096083a729a3bdafcb24e2R64-R66)

File organization:

* Moved and renamed the workflow file from `crossplane-dapr/.github/workflows/ci.yml` to `.github/workflows/crossplane-dapr.yml` for better organization and discoverability.