### PR TITLE
Fix workflow conditional for PUSHGATEWAY secret

### DIFF
--- a/.github/workflows/crossplane-dapr.yml
+++ b/.github/workflows/crossplane-dapr.yml
@@ -51,7 +51,7 @@ jobs:
         run: ./gradlew collectTestPyramidMetrics
 
       - name: Publish test pyramid metrics
-        if: ${{ secrets.PUSHGATEWAY_URL != '' }}
+        if: ${{ env.PUSHGATEWAY_URL != '' }}
         env:
           PUSHGATEWAY_URL: ${{ secrets.PUSHGATEWAY_URL }}
           PUSH_HISTORY: "false"

--- a/.github/workflows/crossplane-dapr.yml
+++ b/.github/workflows/crossplane-dapr.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Publish test pyramid metrics
         if: ${{ env.PUSHGATEWAY_URL != '' }}
         env:
-          PUSHGATEWAY_URL: ${{ secrets.PUSHGATEWAY_URL }}
+          PUSHGATEWAY_URL: ${{ env.PUSHGATEWAY_URL }}
           PUSH_HISTORY: "false"
           SKIP_TEST_EXECUTION: "true"
         run: ./scripts/push-test-pyramid-metrics.sh "$PUSHGATEWAY_URL" "test-pyramid-latest" "latest"


### PR DESCRIPTION
This pull request makes a small update to the workflow condition for publishing test pyramid metrics. The check now uses the environment variable instead of the secrets context to determine if the step should run.